### PR TITLE
Migrate to App Build Suite (ABS) for Helm chart building

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,6 @@
+replace-chart-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/irsa-servicemonitors
+destination: build
+catalog-base-url: https://giantswarm.github.io/default-catalog/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,21 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.27.0
+  architect: giantswarm/architect@6.11.0
 
 workflows:
-  version: 2
   build:
     jobs:
       - architect/push-to-app-catalog:
           context: architect
+          executor: app-build-suite
           name: "push-to-default-app-catalog"
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
           chart: "irsa-servicemonitors"
           filters:
-            # Trigger the job also on git tag.
+            branches:
+              ignore:
+                - main
+                - master
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to App Build Suite (ABS) for building and publishing Helm charts.
+
 ## [0.1.0] - 2024-06-25
 
 ## [0.0.1] - 2023-02-24

--- a/helm/irsa-servicemonitors/Chart.yaml
+++ b/helm/irsa-servicemonitors/Chart.yaml
@@ -1,11 +1,12 @@
 apiVersion: v2
-description: IRSA ServiceMonitors
 name: irsa-servicemonitors
-version: [[ .Version ]]
+version: 0.1.0-dev
+description: IRSA ServiceMonitors
 appVersion: 1.0.0
-annotations:
-  application.giantswarm.io/team: "phoenix"
 home: https://github.com/giantswarm/irsa-servicemonitors-app
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
+annotations:
+  io.giantswarm.application.team: phoenix
 keywords:
   - monitoring
 restrictions:

--- a/helm/irsa-servicemonitors/templates/_helpers.tpl
+++ b/helm/irsa-servicemonitors/templates/_helpers.tpl
@@ -42,5 +42,5 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.releaseLabel }}
 release: {{ .Release.Name }}
 {{- end }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 {{- end }}

--- a/helm/irsa-servicemonitors/values.schema.json
+++ b/helm/irsa-servicemonitors/values.schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "kubernetes": {
+                    "type": "object",
+                    "properties": {
+                        "clusterDomain": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Description

This PR migrates the repository to use App Build Suite (ABS) for building and publishing Helm charts.

## Changes

- Update architect orb to v6.11.0
- Add `executor: app-build-suite` to CircleCI `push-to-app-catalog` job
- Create `.abs/main.yaml` configuration
- Update `Chart.yaml`: add icon, update annotations to new format
- Update `_helpers.tpl`: read team from new annotation format
- Create `values.schema.json`

## Testing

CI will validate the ABS build process.